### PR TITLE
Responsive NavBar Updates

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10978,6 +10978,34 @@ https://flickity.metafizzy.co
   }
 }
 
+@media (max-width: 1195px) {
+  .navbar .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+    line-height: 1.3em;
+    padding-top: 29px;
+  }
+}
+
+@media (max-width: 1080px) {
+  .navbar .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+    line-height: 1.3em;
+    padding-top: 29px;
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 930px) {
+  .navbar .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+    line-height: 1.3em;
+    padding-top: 18px;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar .container-inner .branding-bar .navbar-brand {
+    width: 100px;
+  }
+}
+
 .navbar-dark {
   border-bottom: solid 1px rgba(255, 255, 255, 0.25);
   padding-top: 0px;
@@ -10998,8 +11026,9 @@ https://flickity.metafizzy.co
 }
 
 .navbar-dark .navbar-nav .nav-item .nav-link:hover {
-  border-bottom: solid 1px #8ca9ff;
+  border-bottom: solid 1px #3054F4;
   color: #FFFFFF;
+  background-color: #3054F4;
 }
 
 .navbar-nav-right {
@@ -11412,7 +11441,6 @@ main {
 
 .nano-card .image-mask-visible {
   height: 400px !important;
-  height: auto;
   visibility: visible;
   display: block;
 }
@@ -11421,12 +11449,9 @@ main {
   width: 100%;
   position: absolute;
   bottom: 0;
-  padding: 0 20px 10px 20px;
+  padding: 10px 20px;
   margin-bottom: 0;
-  background: #fff;
-  background: -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(255, 255, 255, 0.8)));
-  background: linear-gradient(transparent, rgba(255, 255, 255, 0.8));
-  padding-bottom: 10px;
+  background: rgba(255, 255, 255, 0.5);
 }
 
 .help-block {

--- a/resources/assets/sass/partials/_nano-card.scss
+++ b/resources/assets/sass/partials/_nano-card.scss
@@ -12,7 +12,6 @@
 .nano-card {
   .image-mask-visible {
     height: 400px !important;
-    height: auto;
     visibility: visible;
     display: block;
   }
@@ -21,10 +20,8 @@
     width: 100%;
     position: absolute;
     bottom: 0;
-    padding: 0 20px 10px 20px;
+    padding: 10px 20px;
     margin-bottom: 0;
-    background: #fff;
-    background: -webkit-linear-gradient(transparent, rgba(255, 255, 255, .8));
-    background: linear-gradient(transparent, rgba(255, 255, 255, .8));
+    background: rgba(255, 255, 255, 0.5);
   }
 }

--- a/resources/assets/sass/partials/_nano-card.scss
+++ b/resources/assets/sass/partials/_nano-card.scss
@@ -6,7 +6,7 @@
 }
 
 .nano-card:hover .card-title a {
-  color: #3054F4;
+  color: $blue;
 }
 
 .nano-card {

--- a/resources/assets/sass/partials/_navbar.scss
+++ b/resources/assets/sass/partials/_navbar.scss
@@ -51,7 +51,7 @@
     }
   }
   @media (min-width: 768px) {
-    .container-inner{
+    .container-inner {
       flex-direction: row;
       .navbar-collapse{
         .collapse-inner{
@@ -70,6 +70,34 @@
           }
         }
       }
+    }
+  }
+
+  @media (max-width: 1195px) {
+    .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+      line-height: 1.3em;
+      padding-top: 29px;
+    }
+  }
+
+  @media (max-width: 1080px) {
+    .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+      line-height: 1.3em;
+      padding-top: 29px;
+      font-size: 14px;
+    }
+  }
+
+  @media (max-width: 930px) {
+    .container-inner .navbar-collapse .collapse-inner .navbar-nav .nav-item > a {
+      line-height: 1.3em;
+      padding-top: 18px;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .container-inner .branding-bar .navbar-brand {
+      width: 100px;
     }
   }
 }
@@ -92,8 +120,9 @@
         padding-right:18px;
         margin-bottom:-1px;
         &:hover{
-          border-bottom:solid 1px $navbar-active-border-color;
+          border-bottom:solid 1px $blue;
           color:#FFFFFF;
+          background-color: $blue;
         }
       }
       &.active{


### PR DESCRIPTION
# Navbar responsive updates
- Fixed text overflowing in body on home page on middle sized desktops
- More breakpoints to handle text menus more gracefully
- Added background on hover to provide more feedback
- Some css cleanups

**Before**
![image](https://user-images.githubusercontent.com/1671987/44707457-d9309b80-aaa4-11e8-872a-b64ac13907c3.png)

**After**
![image](https://user-images.githubusercontent.com/1671987/44707469-e51c5d80-aaa4-11e8-97eb-c71e8cb972de.png)

**Added background hover for more feedback**
![image](https://user-images.githubusercontent.com/1671987/44707498-f6656a00-aaa4-11e8-990f-05dffe9b3397.png)

**Added more breakpoints until the menu is replaced with a button**
![image](https://user-images.githubusercontent.com/1671987/44707535-0715e000-aaa5-11e8-988f-1655f1e5c7fe.png)
![image](https://user-images.githubusercontent.com/1671987/44707546-0c732a80-aaa5-11e8-8cbd-76114234f916.png)

# Nano card updates
- Replaced background gradient with semi transparent background for increased readability on dark backgrounds and fixed Safari gradient issue
- Some css cleanups

**Before**
![image](https://user-images.githubusercontent.com/1671987/44707725-9de29c80-aaa5-11e8-9d4e-cd77f7a5c5c9.png)

**After**
![image](https://user-images.githubusercontent.com/1671987/44707744-b2269980-aaa5-11e8-92a5-9758003234e4.png)
